### PR TITLE
List template 2.0 + enigma.js

### DIFF
--- a/common/src/main/java/eu/unipv/epsilon/enigma/template/TemplateRegistry.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/template/TemplateRegistry.java
@@ -92,8 +92,12 @@ public class TemplateRegistry {
                     packageScanner.getClassesInPackage(TEMPLATES_LOCATION_COLLECTION_CONTAINER, collectionClassLoader, true);
             registerAnnotatedClasses(foundClasses.iterator(), collectionTemplates);
         } catch (ClassNotFoundException e) {
-            // No need to return empty iterator, do not register nothing and old collection data is already cleared
+            // Do not register nothing, old collection data is already cleared
             LOG.warn("No classes found or error, registering nothing", e);
+
+            // But we need to set a class loader, we use the application one, used to load builtin template processors.
+            // Otherwise, the ClasspathURLStreamHandler protocol fails to get internal resources.
+            collectionClassLoader = getClass().getClassLoader();
         }
     }
 

--- a/common/src/main/java/eu/unipv/epsilon/enigma/template/api/TemplateArguments.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/template/api/TemplateArguments.java
@@ -3,7 +3,7 @@ package eu.unipv.epsilon.enigma.template.api;
 import java.util.NoSuchElementException;
 
 /** Arguments passed to a template processor to generate its view. */
-public interface TemplateArguments {
+public abstract class TemplateArguments {
 
     /**
      * Returns the argument value associated with the given key.
@@ -19,6 +19,14 @@ public interface TemplateArguments {
      * @return the value of the key
      * @throws NoSuchElementException if the element can not be found
      */
-    String query(String path) throws NoSuchElementException;
+    public abstract String query(String path) throws NoSuchElementException;
+
+    public String query(String path, String defaultValue) {
+        try {
+            return query(path);
+        } catch (NoSuchElementException e) {
+            return defaultValue;
+        }
+    }
 
 }

--- a/common/src/main/java/eu/unipv/epsilon/enigma/template/api/xml/XmlTemplateArguments.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/template/api/xml/XmlTemplateArguments.java
@@ -5,7 +5,7 @@ import org.w3c.dom.Element;
 
 import java.util.*;
 
-public class XmlTemplateArguments implements TemplateArguments {
+public class XmlTemplateArguments extends TemplateArguments {
 
     private final Element documentElement;
     private final Map<String, String> cache = new WeakHashMap<>();
@@ -18,6 +18,7 @@ public class XmlTemplateArguments implements TemplateArguments {
         return documentElement;
     }
 
+    @Override
     public String query(String path) {
         if (cache.containsKey(path))
             return cache.get(path);

--- a/common/src/main/java/eu/unipv/epsilon/enigma/template/builtin/ListTemplate.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/template/builtin/ListTemplate.java
@@ -3,6 +3,8 @@ package eu.unipv.epsilon.enigma.template.builtin;
 import eu.unipv.epsilon.enigma.loader.levels.protocol.ClasspathURLStreamHandler;
 import eu.unipv.epsilon.enigma.template.api.DocumentGenerationEvent;
 import eu.unipv.epsilon.enigma.template.api.Template;
+import eu.unipv.epsilon.enigma.template.api.TemplateArguments;
+import eu.unipv.epsilon.enigma.template.api.xml.XmlTemplateArguments;
 import eu.unipv.epsilon.enigma.template.util.MappedValueInputStream;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -36,16 +38,23 @@ public class ListTemplate {
     private static final URL PAGE_URL =
             ClasspathURLStreamHandler.createURL("assets/templates/list/index.html");
 
+    private static final String QUIZ_TITLE_DEFAULT = "...?";
+    private static final String STYLE_BACKGROUND_DEFAULT = "linear-gradient(#eee, #ccc)";
+
     @Template.EventHandler
     public void generate(DocumentGenerationEvent e) throws IOException {
-        Element args = e.getArgumentsRaw();
-        Element title = (Element) args.getElementsByTagName("title").item(0);
+        TemplateArguments args = e.getArguments();
 
-        NodeList answers = ((Element) args.getElementsByTagName("answers").item(0)).getElementsByTagName("item");
+        // BY NOW, we need to cast back TemplateArguments to perform a raw extractor query to get an XML item
+        // and get array of child nodes. This WILL change in the future, probably with a "queryAll" function.
+        // It is OK that we don't catch the NoSuchElementsException if answers node is not defined.
+        Element answersNode = ((XmlTemplateArguments) args).queryRaw("answers").getNode();
+        NodeList answers = answersNode.getElementsByTagName("item");
 
         MappedValueInputStream page = new MappedValueInputStream(PAGE_URL.openStream());
-        page.addMacro("QUIZ_TITLE", title.getTextContent());
+        page.addMacro("QUIZ_TITLE", args.query("title", QUIZ_TITLE_DEFAULT));
         page.addMacro("QUIZ_ANSWERS", createAnswersHTML(answers));
+        page.addMacro("STYLE_BACKGROUND", args.query("style:background", STYLE_BACKGROUND_DEFAULT));
 
         e.setResponseStream(page);
     }
@@ -55,7 +64,10 @@ public class ListTemplate {
 
         for (int i = 0; i < nodes.getLength(); ++i) {
             Element x = (Element) nodes.item(i);
-            boolean correct = x.getAttribute("correct").equalsIgnoreCase("true");
+
+            // True if it has a "correct" attribute and it is set to true or is empty
+            boolean correct = x.hasAttribute("correct") &&
+                    ("true".equalsIgnoreCase(x.getAttribute("correct")) || x.getAttribute("correct").isEmpty());
             sb.append(String.format("<li%s>%s</li>", correct ? " correct" : "", x.getTextContent()));
         }
 

--- a/common/src/main/resources/assets/enigma.js
+++ b/common/src/main/resources/assets/enigma.js
@@ -1,0 +1,81 @@
+/* enigma.js - simple interface for Enigma API interaction and common quest behavior */
+
+'use strict';
+
+// --- Library API ---
+
+function _e(arg) {
+    // Allows invocation '_e(...)', reserved for future functionalities
+}
+
+Object.defineProperties(_e, {
+    /** 'true' if the Enigma API was found. */
+    'linked': {
+        value: typeof enigma !== 'undefined'
+    },
+    /** 'true' if this quest is solved. */
+    'solved': {
+        get: function () { return _e.linked && enigma.getComplete(); }
+    },
+    /** Alias of '_e.solved' */
+    'completed': {
+        get: function () { return _e.solved; }
+    }
+});
+
+/** Marks a quiz as solved */
+_e.solve = function () {
+    if (!_e.linked) return;
+    _e._showCompletionForeground(true);
+    enigma.setComplete();
+};
+
+/** Alias of '_e.solve' */
+_e.complete = _e.solve;
+
+
+// --- Internal implementation ---
+
+_e._cbLoad = function () {
+    if (!_e.linked) {
+        _e._showLinkError();
+        return;
+    }
+
+    if (_e.solved)
+        _e._showCompletionForeground(false);
+};
+
+_e._showLinkError = function () {
+    var tag = document.createElement('div');
+    tag.style.cssText = '' +
+        'position: fixed; top: 0; left: 0; width: 100%;' +
+        'padding: 4pt; color: white; background-color: rgba(220, 0, 0, .8);' +
+        'font: .7em "Trebuchet MS", sans-serif; text-align: center;';
+    tag.innerHTML = '<b>The Enigma API could not be found</b>: ' +
+        'this is probably because you started this page on a web browser rather than directly in the app.';
+    document.body.insertBefore(tag, document.body.firstChild);
+};
+
+_e._showCompletionForeground = function (fade) {
+    // Show a black semitransparent overlay to show that this quiz is unavailable / completed
+    var fg = document.createElement('div');
+    fg.style.cssText = 'position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: black;';
+
+    if (fade) {
+        fg.style.opacity = '0';
+        fg.style.transition = 'opacity .5s linear';
+        document.body.appendChild(fg);
+        setTimeout(function () {
+            fg.style.opacity = '.35';
+        }, 50);
+    } else {
+        fg.style.opacity = '.35';
+        document.body.appendChild(fg);
+    }
+};
+
+
+
+
+window.addEventListener('load', _e._cbLoad);

--- a/common/src/main/resources/assets/templates/list/index.html
+++ b/common/src/main/resources/assets/templates/list/index.html
@@ -13,6 +13,9 @@
     <meta name="keywords" content="quiz, ffs, random, dynamic, template">
     <meta name="description" content="Template extracted from the first epic quiz in project Enigma">
 
+    <!-- '_e' enigma.js helper library -->
+    <script src="cp:/assets/enigma.js"></script>
+
     <!-- Load page style and core script -->
     <link rel="stylesheet" href="cp:/assets/templates/list/style.css" />
     <script src="cp:/assets/templates/list/logic.js"></script>

--- a/common/src/main/resources/assets/templates/list/index.html
+++ b/common/src/main/resources/assets/templates/list/index.html
@@ -10,125 +10,20 @@
 
     <!-- Pragmatic Media Lab! Add some metadata if you want... -->
     <meta name="author" content="Luca Defilippi, Luca Zanussi">
-    <meta name="keywords" content="quiz, cinema, South Park">
-    <meta name="description" content="First epic quiz in project Enigma">
+    <meta name="keywords" content="quiz, ffs, random, dynamic, template">
+    <meta name="description" content="Template extracted from the first epic quiz in project Enigma">
 
-    <!-- CSS Style: Fancy things go in here, a lot, but don't be scared,
-         I suggest you to skip reading this and go directly to the <body>. -->
-    <style>
+    <!-- Load page style and core script -->
+    <link rel="stylesheet" href="cp:/assets/templates/list/style.css" />
+    <script src="cp:/assets/templates/list/logic.js"></script>
+    <!-- FOR LOCAL DEBUG <link rel="stylesheet" href="style.css"/> <script src="logic.js"></script> -->
 
-        @-webkit-keyframes inOut {
-            0%   { transform: scale(1.0); }
-            50%  { transform: scale(0.8); }
-            100% { transform: scale(1.0); }
-        }
-
-        .fullscreen {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-        }
-
-        #bg {
-            background: linear-gradient(#eee, #ccc);
-        }
-
-        #fg {
-            background-color: rgba(0, 0, 0, .35);
-            visibility: hidden;
-        }
-
-        body {
-            text-align: center;
-            font-family: 'Open Sans', sans-serif;
-        }
-
-        h1 {
-            font-size: 1.5em;
-            font-weight: 300;
-            margin: 50pt 20pt 20pt 20pt;
-            color: royalblue;
-        }
-
-        ul {
-            list-style-type: none;
-            padding: 0;
-            text-align: center;
-        }
-
-        li {
-            width: 50%;
-            margin: 10pt auto;
-            padding: 4pt 0;
-            font-size: 9pt;
-            letter-spacing: 1.5pt;
-            text-transform: uppercase;
-            transition: background-color .3s;
-            background-color: rgba(0, 0, 0, .05);
-            cursor: pointer;
-        }
-
-        li:hover { background-color: rgba(0, 0, 0, .12); }
-        li.success, li.success:hover { background-color: greenyellow;}
-        li.failure, li.failure:hover { background-color: red; }
-
-		li.success { -webkit-animation: inOut .5s ease-in-out; }
-
-    </style>
-
-    <!-- JavaScript here, don't worry: it's only text, random text -->
-    <script>
-        'use strict';
-
-        window.addEventListener('load', function () {
-            // Add overlay if quiz is complete
-            if (typeof enigma !== 'undefined' && enigma.getComplete())
-                document.getElementById('fg').style.visibility = 'visible';
-        });
-
-        // The function called on page load, will be registered later at the end of the script.
-        function loadProc() {
-
-            var elements = document.getElementById("answers").getElementsByTagName("li");
-            for (var i = 0; i < elements.length; i++) {
-                if (elements[i].hasAttribute("correct"))
-                    elements[i].onclick = cbSuccess;
-                else
-                    elements[i].onclick = cbFailure;
-            }
-        }
-
-        // Function called on exact answer
-        function cbSuccess() {
-            if (typeof enigma === 'undefined') {
-                // We are not running inside the app
-                var title = document.querySelector('h1');
-                title.innerHTML = '- Wrong API Error -';
-                title.style.color = 'red';
-                return;
-            }
-
-            enigma.setComplete();
-            this.classList.add('success');
-        }
-
-        // Epic fail handling (opposite as previous function)
-        function cbFailure() {
-		this.classList.add('failure');
-        }
-
-        // Exec 'loadProc' only when the document is fully loaded,
-        // so it can find its elements (e.g. #1st-elem, etc.).
-        window.addEventListener('load', loadProc)
-
-    </script>
+    <style> #bg { background: ${STYLE_BACKGROUND}; } </style>
 </head>
 <body>
 
-    <!-- This page is very clean now, keep in mind that the JavaScript and CSS above can
-         be moved to an external file so that this HTML file can be less than 40 lines. -->
+    <!-- This page is very clean now that JavaScript and CSS are placed in external files,
+         browsers will like this too, so external content can be cached between different pages. -->
 
     <div id="bg" class="fullscreen">
         <!-- Questionable elements position -->
@@ -137,8 +32,6 @@
 
         <ul id="answers">${QUIZ_ANSWERS}</ul>
     </div>
-
-    <div id="fg" class="fullscreen"></div>
 
 </body>
 </html>

--- a/common/src/main/resources/assets/templates/list/logic.js
+++ b/common/src/main/resources/assets/templates/list/logic.js
@@ -2,37 +2,20 @@
 
 'use strict';
 
+// Function called after page load, so we can look at the full DOM.
 window.addEventListener('load', function () {
-    // Add overlay if quiz is complete
-    if (typeof enigma !== 'undefined' && enigma.getComplete())
-        showCompletedForeground(false);
-});
-
-// The function called on page load, will be registered later at the end of the script.
-function loadProc() {
-
-    var elements = document.getElementById("answers").getElementsByTagName("li");
+    var elements = document.querySelectorAll('#answers li');
     for (var i = 0; i < elements.length; i++) {
-        if (elements[i].hasAttribute("correct"))
+        if (elements[i].hasAttribute('correct'))
             elements[i].onclick = cbSuccess;
         else
             elements[i].onclick = cbFailure;
     }
-}
+});
 
 // Function called on exact answer
 function cbSuccess() {
-    showCompletedForeground(true);
-
-    if (typeof enigma === 'undefined') {
-        // We are not running inside the app
-        var title = document.querySelector('h1');
-        title.innerHTML = '- Wrong API Error -';
-        title.style.color = 'red';
-        return;
-    }
-
-    enigma.setComplete();
+    _e.solve();
     this.classList.add('success');
 }
 
@@ -40,26 +23,3 @@ function cbSuccess() {
 function cbFailure() {
     this.classList.add('failure');
 }
-
-// Shows a black semitransparent overlay to show that this quiz is unavailable
-function showCompletedForeground(fade) {
-    var fg = document.createElement('div');
-    fg.classList.add('fullscreen');
-    fg.style.backgroundColor = 'black';
-
-    if (fade) {
-        fg.style.opacity = '0';
-        fg.style.transition = 'opacity .5s linear';
-        document.body.appendChild(fg);
-        setTimeout(function () {
-            fg.style.opacity = '.35';
-        }, 50);
-    } else {
-        fg.style.opacity = '.35';
-        document.body.appendChild(fg);
-    }
-}
-
-// Exec 'loadProc' only when the document is fully loaded,
-// so it can find its elements (e.g. #1st-elem, etc.).
-window.addEventListener('load', loadProc);

--- a/common/src/main/resources/assets/templates/list/logic.js
+++ b/common/src/main/resources/assets/templates/list/logic.js
@@ -1,0 +1,65 @@
+/* JavaScript here, don't worry: it's only text, random text */
+
+'use strict';
+
+window.addEventListener('load', function () {
+    // Add overlay if quiz is complete
+    if (typeof enigma !== 'undefined' && enigma.getComplete())
+        showCompletedForeground(false);
+});
+
+// The function called on page load, will be registered later at the end of the script.
+function loadProc() {
+
+    var elements = document.getElementById("answers").getElementsByTagName("li");
+    for (var i = 0; i < elements.length; i++) {
+        if (elements[i].hasAttribute("correct"))
+            elements[i].onclick = cbSuccess;
+        else
+            elements[i].onclick = cbFailure;
+    }
+}
+
+// Function called on exact answer
+function cbSuccess() {
+    showCompletedForeground(true);
+
+    if (typeof enigma === 'undefined') {
+        // We are not running inside the app
+        var title = document.querySelector('h1');
+        title.innerHTML = '- Wrong API Error -';
+        title.style.color = 'red';
+        return;
+    }
+
+    enigma.setComplete();
+    this.classList.add('success');
+}
+
+// Epic fail handling (opposite as previous function)
+function cbFailure() {
+    this.classList.add('failure');
+}
+
+// Shows a black semitransparent overlay to show that this quiz is unavailable
+function showCompletedForeground(fade) {
+    var fg = document.createElement('div');
+    fg.classList.add('fullscreen');
+    fg.style.backgroundColor = 'black';
+
+    if (fade) {
+        fg.style.opacity = '0';
+        fg.style.transition = 'opacity .5s linear';
+        document.body.appendChild(fg);
+        setTimeout(function () {
+            fg.style.opacity = '.35';
+        }, 50);
+    } else {
+        fg.style.opacity = '.35';
+        document.body.appendChild(fg);
+    }
+}
+
+// Exec 'loadProc' only when the document is fully loaded,
+// so it can find its elements (e.g. #1st-elem, etc.).
+window.addEventListener('load', loadProc);

--- a/common/src/main/resources/assets/templates/list/style.css
+++ b/common/src/main/resources/assets/templates/list/style.css
@@ -1,0 +1,55 @@
+
+/*                     CSS Style: Fancy things go in here, a lot, but don't be scared,                     *\
+\* If you don't know what's going on here, I suggest you to skip reading this and go back to 'index.html'. */
+
+/* Original keyframes style partially authored by Luca Defilippi @lucad93 */
+
+@-webkit-keyframes inOut {
+    0%   { transform: scale(1.0); }
+    50%  { transform: scale(0.8); }
+    100% { transform: scale(1.0); }
+}
+
+.fullscreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+body {
+    text-align: center;
+    font-family: 'Open Sans', 'Trebuchet MS', sans-serif;
+}
+
+h1 {
+    font-size: 1.5em;
+    font-weight: 300;
+    margin: 50pt 20pt 20pt 20pt;
+    color: royalblue;
+}
+
+ul {
+    list-style-type: none;
+    padding: 0;
+    text-align: center;
+}
+
+li {
+    width: 50%;
+    margin: 10pt auto;
+    padding: 4pt 0;
+    font-size: 9pt;
+    letter-spacing: 1.5pt;
+    text-transform: uppercase;
+    transition: background-color .3s;
+    background-color: rgba(0, 0, 0, .05);
+    cursor: pointer;
+}
+
+li:hover { background-color: rgba(0, 0, 0, .12); }
+li.success, li.success:hover { background-color: greenyellow;}
+li.failure, li.failure:hover { background-color: red; }
+
+li.success { -webkit-animation: inOut .5s ease-in-out; }


### PR DESCRIPTION
### Optimizations
Javascript code, style and markup of the list template are now in separate files to allow `WebViews` to cache (I don't know if it is actually true since by now we have a different web view for each quiz).

### Styleable
You can now change the background css of list quizzes, load images with `url()`, use `#l337c0de` or `linear-gradient()`.

### Reuse code
`cp:/assets/enigma.js` has built-in checks for API availability and automatically provides visual feedback if a quiz is already solved, avoiding you to do the same checks over and over.