### PR TITLE
Refactoring of metadata parsers

### DIFF
--- a/android-app/src/main/java/eu/unipv/epsilon/enigma/MainActivity.java
+++ b/android-app/src/main/java/eu/unipv/epsilon/enigma/MainActivity.java
@@ -6,7 +6,7 @@ import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.StaggeredGridLayoutManager;
 import android.view.Menu;
 import android.view.MenuItem;
-import eu.unipv.epsilon.enigma.loader.levels.exception.MetadataNotFoundException;
+import eu.unipv.epsilon.enigma.loader.levels.parser.MetadataNotFoundException;
 import eu.unipv.epsilon.enigma.quest.QuestCollection;
 import eu.unipv.epsilon.enigma.ui.main.CollectionsViewAdapter;
 import org.slf4j.Logger;

--- a/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/CollectionContainer.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/CollectionContainer.java
@@ -1,6 +1,6 @@
 package eu.unipv.epsilon.enigma.loader.levels;
 
-import eu.unipv.epsilon.enigma.loader.levels.exception.MetadataNotFoundException;
+import eu.unipv.epsilon.enigma.loader.levels.parser.MetadataNotFoundException;
 import eu.unipv.epsilon.enigma.loader.levels.pool.CachedCollectionsPool;
 import eu.unipv.epsilon.enigma.quest.QuestCollection;
 

--- a/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/EqcFile.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/EqcFile.java
@@ -1,11 +1,7 @@
 package eu.unipv.epsilon.enigma.loader.levels;
 
-import eu.unipv.epsilon.enigma.loader.levels.parser.MetadataNotFoundException;
-import eu.unipv.epsilon.enigma.loader.levels.parser.MetadataParser;
-import eu.unipv.epsilon.enigma.loader.levels.parser.XmlMetaParser;
-import eu.unipv.epsilon.enigma.loader.levels.parser.YamlMetaParser;
+import eu.unipv.epsilon.enigma.loader.levels.parser.EqcMetadataParser;
 import eu.unipv.epsilon.enigma.loader.levels.parser.defaults.ContentChecker;
-import eu.unipv.epsilon.enigma.loader.levels.parser.defaults.DefaultsFactory;
 import eu.unipv.epsilon.enigma.quest.QuestCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,8 +15,6 @@ public class EqcFile extends CollectionContainer implements ContentChecker {
 
     private static final Logger LOG = LoggerFactory.getLogger(EqcFile.class);
     public static final String CONTAINER_FILE_EXTENSION = "eqc";
-    public static final String CONFIG_YAML_FILENAME = "metadata.yaml";
-    public static final String CONFIG_XML_FILENAME = "metadata.xml";
 
     String id;
     ZipFile zipFile;
@@ -33,25 +27,8 @@ public class EqcFile extends CollectionContainer implements ContentChecker {
 
     @Override
     public QuestCollection loadCollectionMeta() throws IOException {
-        String fileName;
-        MetadataParser parser;
-
-        // TODO: Consider removing dependency on parsers and instead pass this CollectionContainer to the parser.
-        //       A "generic" parser can choose the right implementation depending on XML or YAML metadata.
-        //       We can still get a method like this in a facade depending on that generic parser.
-
-        if (containsEntry(CONFIG_YAML_FILENAME)) {
-            fileName = CONFIG_YAML_FILENAME;
-            parser = new YamlMetaParser(id, new DefaultsFactory(this));
-        }
-        else if (containsEntry(CONFIG_XML_FILENAME)) {
-            fileName = CONFIG_XML_FILENAME;
-            parser = new XmlMetaParser(id, new DefaultsFactory(this));
-        }
-        else
-            throw new MetadataNotFoundException(id);
-
-        InputStream entryStream = getEntry(fileName).getStream();
+        EqcMetadataParser parser = new EqcMetadataParser(id, this);
+        InputStream entryStream = getEntry(parser.getSelectedMetadataFilePath()).getStream();
         return parser.loadCollectionMetadata(entryStream);
     }
 

--- a/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/EqcFile.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/EqcFile.java
@@ -1,9 +1,10 @@
 package eu.unipv.epsilon.enigma.loader.levels;
 
-import eu.unipv.epsilon.enigma.loader.levels.exception.MetadataNotFoundException;
+import eu.unipv.epsilon.enigma.loader.levels.parser.MetadataNotFoundException;
 import eu.unipv.epsilon.enigma.loader.levels.parser.MetadataParser;
 import eu.unipv.epsilon.enigma.loader.levels.parser.XmlMetaParser;
 import eu.unipv.epsilon.enigma.loader.levels.parser.YamlMetaParser;
+import eu.unipv.epsilon.enigma.loader.levels.parser.defaults.ContentChecker;
 import eu.unipv.epsilon.enigma.loader.levels.parser.defaults.DefaultsFactory;
 import eu.unipv.epsilon.enigma.quest.QuestCollection;
 import org.slf4j.Logger;
@@ -14,7 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.ZipFile;
 
-public class EqcFile extends CollectionContainer {
+public class EqcFile extends CollectionContainer implements ContentChecker {
 
     private static final Logger LOG = LoggerFactory.getLogger(EqcFile.class);
     public static final String CONTAINER_FILE_EXTENSION = "eqc";

--- a/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/EqcMetadataParser.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/EqcMetadataParser.java
@@ -1,0 +1,42 @@
+package eu.unipv.epsilon.enigma.loader.levels.parser;
+
+import eu.unipv.epsilon.enigma.loader.levels.parser.defaults.ContentChecker;
+import eu.unipv.epsilon.enigma.loader.levels.parser.defaults.DefaultsFactory;
+import eu.unipv.epsilon.enigma.quest.QuestCollection;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Metadata parser for EQC files.
+ * This will select the right parser implementation depending on the metadata format found in the collection container.
+ */
+public class EqcMetadataParser implements MetadataParser {
+
+    public static final String CONFIG_YAML_FILENAME = "metadata.yaml";
+    public static final String CONFIG_XML_FILENAME = "metadata.xml";
+
+    private final String selectedMetadataFilePath;
+    private final MetadataParser parserImpl;
+
+    public EqcMetadataParser(String collectionId, ContentChecker contentChecker) throws MetadataNotFoundException {
+        if (contentChecker.containsEntry(CONFIG_YAML_FILENAME)) {
+            selectedMetadataFilePath = CONFIG_YAML_FILENAME;
+            parserImpl = new YamlMetaParser(collectionId, new DefaultsFactory(contentChecker));
+        } else if (contentChecker.containsEntry(CONFIG_XML_FILENAME)) {
+            selectedMetadataFilePath = CONFIG_XML_FILENAME;
+            parserImpl = new XmlMetaParser(collectionId, new DefaultsFactory(contentChecker));
+        } else
+            throw new MetadataNotFoundException(collectionId);
+    }
+
+    public String getSelectedMetadataFilePath() {
+        return selectedMetadataFilePath;
+    }
+
+    @Override
+    public QuestCollection loadCollectionMetadata(InputStream in) throws IOException {
+        return parserImpl.loadCollectionMetadata(in);
+    }
+
+}

--- a/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/MetadataNotFoundException.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/MetadataNotFoundException.java
@@ -1,4 +1,4 @@
-package eu.unipv.epsilon.enigma.loader.levels.exception;
+package eu.unipv.epsilon.enigma.loader.levels.parser;
 
 import java.io.IOException;
 

--- a/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/defaults/CollectionDefaults.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/defaults/CollectionDefaults.java
@@ -1,16 +1,14 @@
 package eu.unipv.epsilon.enigma.loader.levels.parser.defaults;
 
-import eu.unipv.epsilon.enigma.loader.levels.CollectionContainer;
-
 import java.util.NoSuchElementException;
 
 import static eu.unipv.epsilon.enigma.loader.levels.parser.MetadataParser.*;
 
 public class CollectionDefaults implements FieldProvider {
 
-    CollectionContainer context;
+    ContentChecker context;
 
-    public CollectionDefaults(CollectionContainer context) {
+    public CollectionDefaults(ContentChecker context) {
         this.context = context;
     }
 

--- a/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/defaults/ContentChecker.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/defaults/ContentChecker.java
@@ -1,0 +1,18 @@
+package eu.unipv.epsilon.enigma.loader.levels.parser.defaults;
+
+/**
+ * An interface used by default field providers to generate valid links to existing files.
+ * This is also to remove cyclic dependency with CollectionContainer...
+ */
+public interface ContentChecker {
+
+    /**
+     * Checks if a file exists in this container so that a default
+     * field provider can use its path to set up an undefined metadata url field.
+     *
+     * @param entryPath the file path inside the container, follows ZipFile path format
+     * @return {@code true} if there is an entry with the given path in this container
+     */
+    boolean containsEntry(String entryPath);
+
+}

--- a/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/defaults/DefaultsFactory.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/defaults/DefaultsFactory.java
@@ -1,12 +1,10 @@
 package eu.unipv.epsilon.enigma.loader.levels.parser.defaults;
 
-import eu.unipv.epsilon.enigma.loader.levels.CollectionContainer;
-
 public class DefaultsFactory implements IDefaultsFactory {
 
-    private CollectionContainer context;
+    private ContentChecker context;
 
-    public DefaultsFactory(CollectionContainer context) {
+    public DefaultsFactory(ContentChecker context) {
         this.context = context;
     }
 

--- a/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/defaults/QuestDefaults.java
+++ b/common/src/main/java/eu/unipv/epsilon/enigma/loader/levels/parser/defaults/QuestDefaults.java
@@ -1,17 +1,15 @@
 package eu.unipv.epsilon.enigma.loader.levels.parser.defaults;
 
-import eu.unipv.epsilon.enigma.loader.levels.CollectionContainer;
-
 import java.util.NoSuchElementException;
 
 import static eu.unipv.epsilon.enigma.loader.levels.parser.MetadataParser.*;
 
 public class QuestDefaults implements FieldProvider {
 
-    CollectionContainer context;
+    ContentChecker context;
     int nameIndex;
 
-    public QuestDefaults(CollectionContainer context, int index) {
+    public QuestDefaults(ContentChecker context, int index) {
         this.context = context;
         this.nameIndex = index + 1;
     }


### PR DESCRIPTION
*I think* introducing the `ContentChecker` interface removes a cyclic dependency on `CollectionContainer`, now default field providers use that interface to check if a file really exists in a collection, and `EqcFile` implements it.

Also `EqcFile` is not responsible anymore of selecting the right YAML or XML metadata parser, but the right one is choosen by the proxy `EqcMetadataParser`.